### PR TITLE
NEBULA-794: Add diagnosis to check if websocket endpoint exists

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,6 @@ const diagnoseWebSocket = (endpoint, origin) => {
   return new Promise((resolve, reject) => {
     const client = new WebSocketClient();
     client.on('connectFailed', (error) => {
-      identifyProblem(`Connect Failed: ${error.toString()}`);
       if (!error.code) {
         error.code = "ENOTFOUND";
       }
@@ -32,7 +31,6 @@ const diagnoseWebSocket = (endpoint, origin) => {
     
     client.on('connect', (connection) => {
       connection.on('error', (error) => {
-        identifyProblem(`Connection Error: ${error.toString()}`);
         reject(error);
       });
       connection.on('close', () => {
@@ -43,17 +41,17 @@ const diagnoseWebSocket = (endpoint, origin) => {
     client.connect(endpoint, undefined, origin);
 })};
 
-let hasIdentifiedProblem = false;
-let hasIdentifiedCorsProblem = false;
-const identifyProblem = (...problemDescription) => {
-  hasIdentifiedProblem = true;
-  console.log("⚠️ ", ...problemDescription);
-};
-const identifyCorsProblem = (...problemDescription) => {
-  identifyProblem(...problemDescription);
-  hasIdentifiedCorsProblem = true;
-}
 (async () => {
+  let hasIdentifiedProblem = false;
+  let hasIdentifiedCorsProblem = false;
+  const identifyProblem = (...problemDescription) => {
+    hasIdentifiedProblem = true;
+    console.log("⚠️ ", ...problemDescription);
+  };
+  const identifyCorsProblem = (...problemDescription) => {
+    identifyProblem(...problemDescription);
+    hasIdentifiedCorsProblem = true;
+  }
   const isWebSocket = !!options.endpoint.match(/^wss?:/i);
 
   try {

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 const { Command } = require("commander");
 const got = require("got");
 const { buildClientSchema, validateSchema, getIntrospectionQuery } = require('graphql');
+const WebSocketClient = require('websocket').client;
 
 const program = new Command();
 
@@ -30,73 +31,102 @@ const options = program.opts();
     hasIdentifiedCorsProblem = true;
   }
 
+  const socket = (endpoint) => {
+    return new Promise((resolve, reject) => {
+      const client = new WebSocketClient();
+      client.on('connectFailed', (error) => {
+        identifyProblem(`Connect Failed: ${error.toString()}`);
+        if (!error.code) {
+          error.code = "ECONNFAILED";
+        }
+        reject(error);
+      });
+      
+      client.on('connect', (connection) => {
+        connection.on('error', (error) => {
+          identifyProblem(`Connection Error: ${error.toString()}`);
+          reject(error);
+        });
+        connection.on('close', () => {
+          resolve();
+        });
+      });
+        
+      client.connect(endpoint);
+  })};
+  const isWebSocket = options.endpoint.toLowerCase().startsWith("ws:") || options.endpoint.toLowerCase().startsWith("wss:");
+
   try {
     console.log(`Diagnosing ${options.endpoint}`);
-    const optionsResponse = await got(options.endpoint, {
-      method: "OPTIONS",
-      headers: {
-        "access-control-request-method": "POST",
-        origin: options.origin,
-      },
-      throwHttpErrors: false,
-    });
+    if (isWebSocket) {
+      await socket(options.endpoint);
+    } else {
+      const optionsResponse = await got(options.endpoint, {
+        method: "OPTIONS",
+        headers: {
+          "access-control-request-method": "POST",
+          origin: options.origin,
+        },
+        throwHttpErrors: false,
+      });
 
-    if (optionsResponse.statusCode === 401) {
-      identifyProblem(
-        `OPTIONS response returned 401. Are authorization headers or cookies required?`
-      );
-    } else if (optionsResponse.statusCode === 404) {
-      identifyProblem(
-        `OPTIONS response returned 404. Is the url correct? Are authorization headers or cookies required?`
-      );
-    }
+      if (optionsResponse.statusCode === 401) {
+        identifyProblem(
+          `OPTIONS response returned 401. Are authorization headers or cookies required?`
+        );
+      } else if (optionsResponse.statusCode === 404) {
+        identifyProblem(
+          `OPTIONS response returned 404. Is the url correct? Are authorization headers or cookies required?`
+        );
+      }
 
-    if (
-      !(
-        optionsResponse.headers["access-control-allow-methods"] &&
-        optionsResponse.headers["access-control-allow-methods"].includes("POST")
-      )
-    ) {
-      identifyCorsProblem(
-        `OPTIONS response is missing header 'access-control-allow-methods: POST'`
-      );
-    }
+      if (
+        !(
+          optionsResponse.headers["access-control-allow-methods"] &&
+          optionsResponse.headers["access-control-allow-methods"].includes("POST")
+        )
+      ) {
+        identifyCorsProblem(
+          `OPTIONS response is missing header 'access-control-allow-methods: POST'`
+        );
+      }
 
-    const pingResponse = await got.post(options.endpoint, {
-      json: {
-        query: `query Ping { __typename }`,
-      },
-      headers: {
-        origin: options.origin,
-      },
-      throwHttpErrors: false,
-    });
+      const pingResponse = await got.post(options.endpoint, {
+        json: {
+          query: `query Ping { __typename }`,
+        },
+        headers: {
+          origin: options.origin,
+        },
+        throwHttpErrors: false,
+      });
 
-    if (pingResponse.statusCode === 401) {
-      identifyProblem(
-        `POST response returned 401. Are authorization headers or cookies required?`
-      );
-    } else if (pingResponse.statusCode === 404) {
-      identifyProblem(
-        `POST response returned 404. Is the url correct? Are authorization headers or cookies required?`
-      );
-    }
+      if (pingResponse.statusCode === 401) {
+        identifyProblem(
+          `POST response returned 401. Are authorization headers or cookies required?`
+        );
+      } else if (pingResponse.statusCode === 404) {
+        identifyProblem(
+          `POST response returned 404. Is the url correct? Are authorization headers or cookies required?`
+        );
+      }
 
-    if (
-      !pingResponse.headers["access-control-allow-origin"] ||
-      (pingResponse.headers["access-control-allow-origin"] !== "*" &&
-        pingResponse.headers["access-control-allow-origin"] !== options.origin)
-    ) {
-      identifyCorsProblem(
-        [
-          `POST response missing 'access-control-allow-origin' header.`,
-          `If using cookie-based authentication, the following headers are required from your endpoint: `,
-          `    access-control-allow-origin: https://studio.apollographql.com`,
-          `    access-control-allow-credentials: true`,
-          `Otherwise, a wildcard value would work:`,
-          `    access-control-allow-origin: *`,
-        ].join("\n")
-      );
+      if (
+        !pingResponse.headers["access-control-allow-origin"] ||
+        (pingResponse.headers["access-control-allow-origin"] !== "*" &&
+          pingResponse.headers["access-control-allow-origin"] !== options.origin)
+      ) {
+        identifyCorsProblem(
+          [
+            `POST response missing 'access-control-allow-origin' header.`,
+            `If using cookie-based authentication, the following headers are required from your endpoint: `,
+            `    access-control-allow-origin: https://studio.apollographql.com`,
+            `    access-control-allow-credentials: true`,
+            `Otherwise, a wildcard value would work:`,
+            `    access-control-allow-origin: *`,
+          ].join("\n")
+        );
+      }
     }
   } catch (e) {
     switch (e.code) {
@@ -108,6 +138,11 @@ const options = program.opts();
       case "ECONNREFUSED":
         identifyProblem(
           `Connection refused (ECONNREFUSED)\nIs the address correct?\nIs the server running?`
+        );
+        break;
+      case "ECONNFAILED":
+        identifyProblem(
+          `Bad request\nIs the address correct?\nIs the server running?`
         );
         break;
       default:
@@ -129,7 +164,7 @@ const options = program.opts();
     );
   }
 
-  if (!hasIdentifiedProblem) {
+  if (!hasIdentifiedProblem && !isWebSocket) {
     // Only check for introspection problems if there are no other problems found
     const introspectionQueryResponse = await got.post(options.endpoint, {
       json: {

--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ const options = program.opts();
       client.on('connectFailed', (error) => {
         identifyProblem(`Connect Failed: ${error.toString()}`);
         if (!error.code) {
-          error.code = "ECONNFAILED";
+          error.code = "ENOTFOUND";
         }
         reject(error);
       });
@@ -138,11 +138,6 @@ const options = program.opts();
       case "ECONNREFUSED":
         identifyProblem(
           `Connection refused (ECONNREFUSED)\nIs the address correct?\nIs the server running?`
-        );
-        break;
-      case "ECONNFAILED":
-        identifyProblem(
-          `Bad request\nIs the address correct?\nIs the server running?`
         );
         break;
       default:

--- a/index.js
+++ b/index.js
@@ -140,6 +140,11 @@ const options = program.opts();
           `Connection refused (ECONNREFUSED)\nIs the address correct?\nIs the server running?`
         );
         break;
+      case "EPROTO":
+        identifyProblem(
+          `Protocol wrong type for socket (EPROTO)\nIs the address correct?\nIs the server running?`
+        );
+        break;
       default:
         // unexpected error
         identifyProblem(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,18 @@
 {
   "name": "diagnose-endpoint",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.0.13",
+      "name": "diagnose-endpoint",
+      "version": "1.0.14",
       "license": "MIT",
       "dependencies": {
         "commander": "8.1.0",
         "got": "11.8.2",
-        "graphql": "16.0.0"
+        "graphql": "16.0.0",
+        "websocket": "^1.0.34"
       },
       "bin": {
         "diagnose-endpoint": "index.js"
@@ -75,6 +77,18 @@
         "@types/node": "*"
       }
     },
+    "node_modules/bufferutil": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.6.tgz",
+      "integrity": "sha512-jduaYOYtnio4aIAyc6UbvPCVcgq7nYpVnucyxr6eCYg/Woad9Hf/oxxBRDnGGjPfjUm6j5O/uBWhIu4iLebFaw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
     "node_modules/cacheable-lookup": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
@@ -114,6 +128,23 @@
       "integrity": "sha512-mf45ldcuHSYShkplHHGKWb4TrmwQadxOn7v4WuhDJy0ZVoY5JFajaRDKD0PNe5qXzBX0rhovjTnP6Kz9LETcuA==",
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/d": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+      "dependencies": {
+        "es5-ext": "^0.10.50",
+        "type": "^1.0.1"
+      }
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dependencies": {
+        "ms": "2.0.0"
       }
     },
     "node_modules/decompress-response": {
@@ -156,6 +187,48 @@
       "dependencies": {
         "once": "^1.4.0"
       }
+    },
+    "node_modules/es5-ext": {
+      "version": "0.10.53",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+      "dependencies": {
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "~3.1.3",
+        "next-tick": "~1.0.0"
+      }
+    },
+    "node_modules/es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "node_modules/es6-symbol": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+      "dependencies": {
+        "d": "^1.0.1",
+        "ext": "^1.1.2"
+      }
+    },
+    "node_modules/ext": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.6.0.tgz",
+      "integrity": "sha512-sdBImtzkq2HpkdRLtlLWDa6w4DX22ijZLKx8BMPUuKe1c5lbN6xwQDQCxSfxBQnHZ13ls/FH0MQZx/q/gr6FQg==",
+      "dependencies": {
+        "type": "^2.5.0"
+      }
+    },
+    "node_modules/ext/node_modules/type": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/type/-/type-2.6.0.tgz",
+      "integrity": "sha512-eiDBDOmkih5pMbo9OqsqPRGMljLodLcwd5XD5JbtNB0o89xZAwynY9EdCDsJU7LtcVCClu9DvM7/0Ep1hYX3EQ=="
     },
     "node_modules/get-stream": {
       "version": "5.2.0",
@@ -220,6 +293,11 @@
         "node": ">=10.19.0"
       }
     },
+    "node_modules/is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -247,6 +325,26 @@
       "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "node_modules/next-tick": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
+      "integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q==",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/normalize-url": {
@@ -309,10 +407,59 @@
         "lowercase-keys": "^2.0.0"
       }
     },
+    "node_modules/type": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
+    },
+    "node_modules/typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "dependencies": {
+        "is-typedarray": "^1.0.0"
+      }
+    },
+    "node_modules/utf-8-validate": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.8.tgz",
+      "integrity": "sha512-k4dW/Qja1BYDl2qD4tOMB9PFVha/UJtxTc1cXYOe3WwA/2m0Yn4qB7wLMpJyLJ/7DR0XnTut3HsCSzDT4ZvKgA==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
+    "node_modules/websocket": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.34.tgz",
+      "integrity": "sha512-PRDso2sGwF6kM75QykIesBijKSVceR6jL2G8NGYyq2XrItNC2P5/qL5XeR056GhA+Ly7JMFvJb9I312mJfmqnQ==",
+      "dependencies": {
+        "bufferutil": "^4.0.1",
+        "debug": "^2.2.0",
+        "es5-ext": "^0.10.50",
+        "typedarray-to-buffer": "^3.1.5",
+        "utf-8-validate": "^5.0.2",
+        "yaeti": "^0.0.6"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "node_modules/yaeti": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
+      "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc=",
+      "engines": {
+        "node": ">=0.10.32"
+      }
     }
   },
   "dependencies": {
@@ -366,6 +513,14 @@
         "@types/node": "*"
       }
     },
+    "bufferutil": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.6.tgz",
+      "integrity": "sha512-jduaYOYtnio4aIAyc6UbvPCVcgq7nYpVnucyxr6eCYg/Woad9Hf/oxxBRDnGGjPfjUm6j5O/uBWhIu4iLebFaw==",
+      "requires": {
+        "node-gyp-build": "^4.3.0"
+      }
+    },
     "cacheable-lookup": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
@@ -398,6 +553,23 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-8.1.0.tgz",
       "integrity": "sha512-mf45ldcuHSYShkplHHGKWb4TrmwQadxOn7v4WuhDJy0ZVoY5JFajaRDKD0PNe5qXzBX0rhovjTnP6Kz9LETcuA=="
     },
+    "d": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+      "requires": {
+        "es5-ext": "^0.10.50",
+        "type": "^1.0.1"
+      }
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
     "decompress-response": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
@@ -424,6 +596,50 @@
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "requires": {
         "once": "^1.4.0"
+      }
+    },
+    "es5-ext": {
+      "version": "0.10.53",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+      "requires": {
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "~3.1.3",
+        "next-tick": "~1.0.0"
+      }
+    },
+    "es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "es6-symbol": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+      "requires": {
+        "d": "^1.0.1",
+        "ext": "^1.1.2"
+      }
+    },
+    "ext": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.6.0.tgz",
+      "integrity": "sha512-sdBImtzkq2HpkdRLtlLWDa6w4DX22ijZLKx8BMPUuKe1c5lbN6xwQDQCxSfxBQnHZ13ls/FH0MQZx/q/gr6FQg==",
+      "requires": {
+        "type": "^2.5.0"
+      },
+      "dependencies": {
+        "type": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/type/-/type-2.6.0.tgz",
+          "integrity": "sha512-eiDBDOmkih5pMbo9OqsqPRGMljLodLcwd5XD5JbtNB0o89xZAwynY9EdCDsJU7LtcVCClu9DvM7/0Ep1hYX3EQ=="
+        }
       }
     },
     "get-stream": {
@@ -471,6 +687,11 @@
         "resolve-alpn": "^1.0.0"
       }
     },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
     "json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -493,6 +714,21 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
       "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "next-tick": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
+    },
+    "node-gyp-build": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
+      "integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q=="
     },
     "normalize-url": {
       "version": "6.1.0",
@@ -539,10 +775,49 @@
         "lowercase-keys": "^2.0.0"
       }
     },
+    "type": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
+    },
+    "typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "requires": {
+        "is-typedarray": "^1.0.0"
+      }
+    },
+    "utf-8-validate": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.8.tgz",
+      "integrity": "sha512-k4dW/Qja1BYDl2qD4tOMB9PFVha/UJtxTc1cXYOe3WwA/2m0Yn4qB7wLMpJyLJ/7DR0XnTut3HsCSzDT4ZvKgA==",
+      "requires": {
+        "node-gyp-build": "^4.3.0"
+      }
+    },
+    "websocket": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.34.tgz",
+      "integrity": "sha512-PRDso2sGwF6kM75QykIesBijKSVceR6jL2G8NGYyq2XrItNC2P5/qL5XeR056GhA+Ly7JMFvJb9I312mJfmqnQ==",
+      "requires": {
+        "bufferutil": "^4.0.1",
+        "debug": "^2.2.0",
+        "es5-ext": "^0.10.50",
+        "typedarray-to-buffer": "^3.1.5",
+        "utf-8-validate": "^5.0.2",
+        "yaeti": "^0.0.6"
+      }
+    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "yaeti": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
+      "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "commander": "8.1.0",
     "got": "11.8.2",
-    "graphql": "16.0.0"
+    "graphql": "16.0.0",
+    "websocket": "^1.0.34"
   }
 }


### PR DESCRIPTION
The script fails when checking any ws: or wss: endpoints. Added diagnosis for when a websocket endpoint doesn't exist and when websocket URL doesn't exist.

URL doesn't exist
`node index.js --endpoint=ws://localhost:4001/graphql`
```
Diagnosing WS://localhost:4001/graphql
⚠️  Connect Failed: Error: connect ECONNREFUSED 127.0.0.1:4001
⚠️  Connection refused (ECONNREFUSED)
Is the address correct?
Is the server running?
```

Endpoint doesn't exist
`node index.js --endpoint=ws://localhost:4000/bad`
```
Diagnosing ws://localhost:4000/bad
⚠️  Connect Failed: Error: Server responded with a non-101 status: 400 Bad Request
Response Headers Follow:
connection: close
content-type: text/html
content-length: 11

⚠️  Could not resolve (ENOTFOUND)
Is the address correct?
Is the server running?
```

Incorrect protocol
`node index.js --endpoint=wss://localhost:4000/graphql`
```
Diagnosing wss://localhost:4000/graphql
⚠️  Connect Failed: Error: write EPROTO 4420599104:error:1408F10B:SSL routines:ssl3_get_record:wrong version number:../deps/openssl/openssl/ssl/record/ssl3_record.c:332:

⚠️  Protocol wrong type for socket (EPROTO)
Is the address correct?
Is the server running?
```